### PR TITLE
Fix for grid/table/probably-something-else-as-well rendering

### DIFF
--- a/vaadin-sliderpanel/src/main/java/org/vaadin/sliderpanel/client/VSliderPanel.java
+++ b/vaadin-sliderpanel/src/main/java/org/vaadin/sliderpanel/client/VSliderPanel.java
@@ -325,8 +325,6 @@ public class VSliderPanel extends SimplePanel implements NativePreviewHandler {
             updateTabElemClassName();
 
             if (!VSliderPanel.this.expand) {
-                VSliderPanel.this.contentNode.getStyle()
-                                             .setDisplay(Display.NONE);
                 changeSize(0);
             }
             else {


### PR DESCRIPTION
This seems to fix the issue for me. Not sure if there was some reason to put display to none, but as Grid and some other components try to calculate things from the dom, they fail pretty badly if they are initialized into non visible dom part.

Closes #5
