### PR TITLE
Fix capitalization on widgetset file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add the dependency to your pom the GWT inherits will get automatically added by 
 ```
 
 ```xml
-<inherits name="org.vaadin.sliderpanel.Widgetset" />
+<inherits name="org.vaadin.sliderpanel.WidgetSet" />
 ```
 
 You can recolor the panel by changing the css like:


### PR DESCRIPTION
Change `org.vaadin.sliderpanel.Widgetset` -> `org.vaadin.sliderpanel.WidgetSet` in `inherits` tag example, to reflect actual filename.
